### PR TITLE
Support Docker containers that can restart services.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ dovecot_mailbox_location: mbox:~/mail:INBOX=/var/spool/mail/%u
 # To update all packages installed by this roles, set `dovecot_package_state` to `latest`.
 dovecot_package_state: present
 
+# Some Docker containers do not allow managing services, rebooting and writing
+# to some locations in /etc. The role skips tasks that will typically fail in
+# Docker. With this parameter you can tell the role to -not- skip these tasks.
+dovecot_ignore_docker: yes
+
 ```
 
 Requirements
@@ -98,6 +103,11 @@ molecule test
 ```
 There are many specific scenarios available, please have a look in the `molecule/` directory.
 
+Run the [ansible-galaxy[(https://github.com/ansible/galaxy-lint-rules) and [my](https://github.com/robertdebock/ansible-lint-rules) lint rules if you want your change to be merges:
+```
+ansible-lint -r /path/to/galaxy-lint-rules/rules .
+ansible-lint -r /path/to/ansible-lint-rules/rules .
+```
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,8 @@ dovecot_mailbox_location: mbox:~/mail:INBOX=/var/spool/mail/%u
 
 # To update all packages installed by this roles, set `dovecot_package_state` to `latest`.
 dovecot_package_state: present
+
+# Some Docker containers do not allow managing services, rebooting and writing
+# to some locations in /etc. The role skips tasks that will typically fail in
+# Docker. With this parameter you can tell the role to -not- skip these tasks.
+dovecot_ignore_docker: yes

--- a/molecule/alpine-edge/molecule.yml
+++ b/molecule/alpine-edge/molecule.yml
@@ -13,6 +13,10 @@ platforms:
     command: sh -c "while true ; do sleep 1 ; done"
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/alpine-latest/molecule.yml
+++ b/molecule/alpine-latest/molecule.yml
@@ -13,6 +13,10 @@ platforms:
     command: sh -c "while true ; do sleep 1 ; done"
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/archlinux/molecule.yml
+++ b/molecule/archlinux/molecule.yml
@@ -12,6 +12,10 @@ platforms:
     image: base/archlinux
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/centos-6/molecule.yml
+++ b/molecule/centos-6/molecule.yml
@@ -12,6 +12,10 @@ platforms:
     image: centos:6
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/centos-latest/molecule.yml
+++ b/molecule/centos-latest/molecule.yml
@@ -12,6 +12,10 @@ platforms:
     image: centos:latest
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/debian-latest/molecule.yml
+++ b/molecule/debian-latest/molecule.yml
@@ -12,6 +12,10 @@ platforms:
     image: debian:latest
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/debian-stable/molecule.yml
+++ b/molecule/debian-stable/molecule.yml
@@ -12,6 +12,10 @@ platforms:
     image: debian:stable
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/debian-unstable/molecule.yml
+++ b/molecule/debian-unstable/molecule.yml
@@ -12,6 +12,10 @@ platforms:
     image: debian:unstable
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -38,6 +38,8 @@ platforms:
     image: ubuntu:artful
   - name: dovecot-ubuntu-devel
     image: ubuntu:devel
+  - name: dovecot-ubuntu-latest
+    image: ubuntu:latest
 provisioner:
   name: ansible
   inventory:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -40,6 +40,10 @@ platforms:
     image: ubuntu:devel
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
   config_options:

--- a/molecule/ec2/README.md
+++ b/molecule/ec2/README.md
@@ -1,0 +1,15 @@
+# Amazon EC2
+
+To test on Amazon elastic compute cloud (EC2), set this variable:
+
+```
+export EC2_REGION=eu-central-1
+```
+
+And save the credentials:
+```
+cat ~/.aws/credentials
+[default]
+aws_access_key_id=YOUR_KEY_ID
+aws_secret_access_key=YOUR_ACCESS_KEY
+```

--- a/molecule/ec2/create.yml
+++ b/molecule/ec2/create.yml
@@ -1,0 +1,125 @@
+---
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  vars:
+    ssh_user: ec2-user
+    ssh_port: 22
+
+    security_group_name: molecule
+    security_group_description: Security group for testing Molecule
+    security_group_rules:
+      - proto: tcp
+        from_port: "{{ ssh_port }}"
+        to_port: "{{ ssh_port }}"
+        cidr_ip: '0.0.0.0/0'
+      - proto: icmp
+        from_port: 8
+        to_port: -1
+        cidr_ip: '0.0.0.0/0'
+    security_group_rules_egress:
+      - proto: -1
+        from_port: 0
+        to_port: 0
+        cidr_ip: '0.0.0.0/0'
+
+    keypair_name: molecule_key
+    keypair_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/ssh_key"
+  tasks:
+    - name: Create security group
+      ec2_group:
+        name: "{{ security_group_name }}"
+        description: "{{ security_group_name }}"
+        rules: "{{ security_group_rules }}"
+        rules_egress: "{{ security_group_rules_egress }}"
+
+    - name: Test for presence of local keypair
+      stat:
+        path: "{{ keypair_path }}"
+      register: keypair_local
+
+    - name: Delete remote keypair
+      ec2_key:
+        name: "{{ keypair_name }}"
+        state: absent
+      when: not keypair_local.stat.exists
+
+    - name: Create keypair
+      ec2_key:
+        name: "{{ keypair_name }}"
+      register: keypair
+
+    - name: Persist the keypair
+      copy:
+        dest: "{{ keypair_path }}"
+        content: "{{ keypair.key.private_key }}"
+        mode: 0600
+      when: keypair.changed
+
+    - name: Create molecule instance(s)
+      ec2:
+        key_name: "{{ keypair_name }}"
+        image: "{{ item.image }}"
+        instance_type: "{{ item.instance_type }}"
+        vpc_subnet_id: "{{ item.vpc_subnet_id }}"
+        group: "{{ security_group_name }}"
+        instance_tags:
+          instance: "{{ item.name }}"
+        wait: true
+        assign_public_ip: true
+        exact_count: 1
+        count_tag:
+          instance: "{{ item.name }}"
+      register: server
+      with_items: "{{ molecule_yml.platforms }}"
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) creation to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: ec2_jobs
+      until: ec2_jobs.finished
+      retries: 300
+      with_items: "{{ server.results }}"
+
+    # Mandatory configuration for Molecule to function.
+
+    - name: Populate instance config dict
+      set_fact:
+        instance_conf_dict: {
+          'instance': "{{ item.instances[0].tags.instance }}",
+          'address': "{{ item.instances[0].public_ip }}",
+          'user': "{{ ssh_user }}",
+          'port': "{{ ssh_port }}",
+          'identity_file': "{{ keypair_path }}",
+          'instance_ids': "{{ item.instance_ids }}", }
+      with_items: "{{ ec2_jobs.results }}"
+      register: instance_config_dict
+      when: server.changed | bool
+
+    - name: Convert instance config dict to a list
+      set_fact:
+        instance_conf: "{{ instance_config_dict.results | map(attribute='ansible_facts.instance_conf_dict') | list }}"
+      when: server.changed | bool
+
+    - name: Dump instance config
+      copy:
+        content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
+        dest: "{{ molecule_instance_config }}"
+      when: server.changed | bool
+
+    - name: Wait for SSH
+      wait_for:
+        port: "{{ ssh_port }}"
+        host: "{{ item.address }}"
+        search_regex: SSH
+        delay: 10
+        timeout: 320
+      with_items: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"
+
+    - name: Wait for boot process to finish
+      pause:
+        minutes: 2

--- a/molecule/ec2/destroy.yml
+++ b/molecule/ec2/destroy.yml
@@ -1,0 +1,47 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  tasks:
+    - block:
+        - name: Populate instance config
+          set_fact:
+            instance_conf: "{{ lookup('file', molecule_instance_config) | molecule_from_yaml }}"
+            skip_instances: false
+      rescue:
+        - name: Populate instance config when file missing
+          set_fact:
+            instance_conf: {}
+            skip_instances: true
+
+    - name: Destroy molecule instance(s)
+      ec2:
+        state: absent
+        instance_ids: "{{ item.instance_ids }}"
+      register: server
+      with_items: "{{ instance_conf }}"
+      when: not skip_instances
+      async: 7200
+      poll: 0
+
+    - name: Wait for instance(s) deletion to complete
+      async_status:
+        jid: "{{ item.ansible_job_id }}"
+      register: ec2_jobs
+      until: ec2_jobs.finished
+      retries: 300
+      with_items: "{{ server.results }}"
+
+    # Mandatory configuration for Molecule to function.
+
+    - name: Populate instance config
+      set_fact:
+        instance_conf: {}
+
+    - name: Dump instance config
+      copy:
+        content: "{{ instance_conf | to_json | from_json | molecule_to_yaml | molecule_header }}"
+        dest: "{{ molecule_instance_config }}"
+      when: server.changed | bool

--- a/molecule/ec2/molecule.yml
+++ b/molecule/ec2/molecule.yml
@@ -1,0 +1,81 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: requirements.yml
+driver:
+  name: ec2
+lint:
+  name: yamllint
+platforms:
+  # - name: rhel-7
+  #   image: ami-c86c3f23
+  #   instance_type: t2.micro
+  #   vpc_subnet_id: subnet-0e688067
+  # - name: sles-15
+  #   image: ami-0a1886cf45f944eb1
+  #   instance_type: t2.micro
+  #   vpc_subnet_id: subnet-0e688067
+  - name: dovecot-ubuntu-18.04
+    image: ami-0bdf93799014acdc4
+    instance_type: t2.micro
+    vpc_subnet_id: subnet-0e688067
+  - name: dovecot-amazon-linux-2
+    image: ami-02ea8f348fa28c108
+    instance_type: t2.micro
+    vpc_subnet_id: subnet-0e688067
+  - name: dovecot-centos-7
+    image: ami-9a183671
+    instance_type: t2.micro
+    vpc_subnet_id: subnet-0e688067
+  - name: dovecot-fedora-29
+    image: ami-0f904cfaa69a1c64c
+    instance_type: t2.micro
+    vpc_subnet_id: subnet-0e688067
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  config_options:
+    defaults:
+      callback_plugins: /usr/lib/python2.7/site-packages/ara/plugins/callbacks
+  inventory:
+    host_vars:
+      dovecot-ubuntu-18.04:
+        ansible_user: ubuntu
+      dovecot-centos-7:
+        ansible_user: centos
+      dovecot-fedora-29:
+        ansible_user: fedora
+scenario:
+  name: ec2
+  create_sequence:
+    - create
+  check_sequence:
+    - destroy
+    - dependency
+    - create
+    - converge
+    - check
+    - destroy
+  converge_sequence:
+    - dependency
+    - create
+    - converge
+  destroy_sequence:
+    - destroy
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - converge
+    - idempotence
+    - side_effect
+    - verify
+    - destroy
+verifier:
+  name: goss
+  lint:
+    name: yamllint

--- a/molecule/ec2/playbook.yml
+++ b/molecule/ec2/playbook.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: true
+
+  roles:
+    - robertdebock.bootstrap
+    - ansible-role-dovecot

--- a/molecule/ec2/tests/test_default.yml
+++ b/molecule/ec2/tests/test_default.yml
@@ -1,0 +1,8 @@
+# Molecule managed
+
+---
+file:
+  /etc/hosts:
+    exists: true
+    owner: root
+    group: root

--- a/molecule/ec2/verify.yml
+++ b/molecule/ec2/verify.yml
@@ -1,0 +1,53 @@
+---
+# This is an example playbook to execute goss tests.
+# Tests need distributed to the appropriate ansible host/groups
+# prior to execution by `goss validate`.
+
+- name: Verify
+  hosts: all
+  become: true
+  vars:
+    goss_version: v0.3.2
+    goss_arch: amd64
+    goss_dst: /usr/local/bin/goss
+    goss_sha256sum: 2f6727375db2ea0f81bee36e2c5be78ab5ab8d5981f632f761b25e4003e190ec
+    goss_url: "https://github.com/aelsabbahy/goss/releases/download/{{ goss_version }}/goss-linux-{{ goss_arch }}"
+    goss_test_directory: /tmp
+    goss_format: documentation
+  tasks:
+    - name: Download and install Goss
+      get_url:
+        url: "{{ goss_url }}"
+        dest: "{{ goss_dst }}"
+        sha256sum: "{{ goss_sha256sum }}"
+        mode: 0755
+      register: download_goss
+      until: download_goss is succeeded
+      retries: 3
+
+    - name: Copy Goss tests to remote
+      copy:
+        src: "{{ item }}"
+        dest: "{{ goss_test_directory }}/{{ item | basename }}"
+      with_fileglob:
+        - "{{ lookup('env', 'MOLECULE_VERIFIER_TEST_DIRECTORY') }}/test_*.yml"
+
+    - name: Register test files
+      shell: "ls {{ goss_test_directory }}/test_*.yml"
+      register: test_files
+
+    - name: Execute Goss tests
+      command: "{{ goss_dst }} -g {{ item }} validate --format {{ goss_format }}"
+      register: test_results
+      with_items: "{{ test_files.stdout_lines }}"
+
+    - name: Display details about the Goss results
+      debug:
+        msg: "{{ item.stdout_lines }}"
+      with_items: "{{ test_results.results }}"
+
+    - name: Fail when tests fail
+      fail:
+        msg: "Goss failed to validate"
+      when: item.rc != 0
+      with_items: "{{ test_results.results }}"

--- a/molecule/fedora-latest/molecule.yml
+++ b/molecule/fedora-latest/molecule.yml
@@ -12,6 +12,10 @@ platforms:
     image: fedora:latest
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/fedora-rawhide/molecule.yml
+++ b/molecule/fedora-rawhide/molecule.yml
@@ -14,6 +14,10 @@ platforms:
       url: registry.fedoraproject.org
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/opensuse-leap/molecule.yml
+++ b/molecule/opensuse-leap/molecule.yml
@@ -12,6 +12,10 @@ platforms:
     image: opensuse:leap
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/opensuse-tumbleweed/molecule.yml
+++ b/molecule/opensuse-tumbleweed/molecule.yml
@@ -12,6 +12,10 @@ platforms:
     image: opensuse:tumbleweed
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/ubuntu-artful/molecule.yml
+++ b/molecule/ubuntu-artful/molecule.yml
@@ -12,6 +12,10 @@ platforms:
     image: ubuntu:artful
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/ubuntu-devel/molecule.yml
+++ b/molecule/ubuntu-devel/molecule.yml
@@ -12,6 +12,10 @@ platforms:
     image: ubuntu:devel
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/ubuntu-latest/molecule.yml
+++ b/molecule/ubuntu-latest/molecule.yml
@@ -12,6 +12,10 @@ platforms:
     image: ubuntu:latest
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      all:
+        dovecot_ignore_docker: no
   lint:
     name: ansible-lint
 scenario:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,4 +23,4 @@
     enabled: yes
   with_items: "{{ dovecot_service }}"
   when:
-    - ansible_virtualization_type != "docker"
+    - ansible_virtualization_type != "docker" or dovecot_ignore_docker


### PR DESCRIPTION
---
name: Pull request
about: Allow all docker-excluded tasks to run by default, but not in molecule.

---

**Describe the change**
As described in #2, there can be situations where services should be started, even though running in Docker. Most Docker containers do not allow managing services in Docker.

Testing (molecule on Travis) uses 'normal' Docker containers, so the provided molecule examples do not managed services.

**Testing**
Travis and locally.